### PR TITLE
ROM container needs a sql connection

### DIFF
--- a/system/boot/persistence.rb
+++ b/system/boot/persistence.rb
@@ -1,6 +1,6 @@
 Bix::Application.boot(:persistence) do |app|
   start do
-    container = ROM.container(:sql, app['db.connection']) do |config|
+    container = ROM.container(:sql, app['db.config'].gateways[:default].connection) do |config|
       config.auto_registration(app.root + "lib/bix")
     end
     register('container', container)


### PR DESCRIPTION
The ROM Container needs a connection, since we are using
a ROM::Configuration in `db.config` we have to pass this in
here too and use the default gateway connection.